### PR TITLE
Removed redundant leftover argument checking

### DIFF
--- a/ipfetch
+++ b/ipfetch
@@ -2,11 +2,6 @@
 
 tempfile=`mktemp -u /tmp/ipfetch.XXXXXX`
 IP=""
-  
-if [ "$1" == "-ip" ] >/dev/null 2>&1 ; then
-	wget https://ip.seeip.org/geoip/$2 -O "$tempfile" >/dev/null 2>&1 || exit 1
-fi
-
 
 usage() {
 	cat <<- _end_of_usage  


### PR DESCRIPTION
Some argument checking was left over due to inconsistent merging. Went ahead and removed it.