### PR TITLE
Modify file hierarchy

### DIFF
--- a/ipfetch
+++ b/ipfetch
@@ -58,9 +58,9 @@ ipfetch() {
 	rm "$tempfile"
 
 	# All of those \033 you see are cursor positions.
-	#Here is a good tutorial for it: https://thoughtsordiscoveries.wordpress.com/2017/04/26/set-and-read-cursor-position-in-terminal-windows-and-linux/
+	# Here is a good tutorial for it: https://thoughtsordiscoveries.wordpress.com/2017/04/26/set-and-read-cursor-position-in-terminal-windows-and-linux/
 	
-	echo -e "\n`cat /usr/share/ipfetch/$flag`\
+	echo -e "\n`cat ~/.local/share/ipfetch/$flag`\
 		\033[9D\033[s \033[9A Ip: $ip\
 		\033[u\033[8A  Continent: $continent\
 		\033[u\033[7A  Country: $country\

--- a/setup.sh
+++ b/setup.sh
@@ -7,4 +7,4 @@ chmod -R 755 ~/.local/share/ipfetch
 cp ./ipfetch ~/.local/bin/
 chmod 755 ~/.local/bin/ipfetch
 
-echo "ipfetch has been succesfully installed."
+echo "ipfetch has been successfully installed."

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+mkdir -p ~/.local/bin
+
 mkdir -p ~/.local/share/ipfetch
 cp ./flags/* ~/.local/share/ipfetch/
 chmod -R 755 ~/.local/share/ipfetch

--- a/setup.sh
+++ b/setup.sh
@@ -10,3 +10,4 @@ cp ./ipfetch ~/.local/bin/
 chmod 755 ~/.local/bin/ipfetch
 
 echo "ipfetch has been successfully installed."
+echo "please make sure that $HOME/.local/bin is in your PATH."

--- a/setup.sh
+++ b/setup.sh
@@ -1,14 +1,10 @@
 #!/usr/bin/env bash
-if [[ $EUID -ne 0 ]]; then
-   echo "Install script must be run as root" 
-   exit 1
-fi
 
-mkdir -p /usr/share/ipfetch
-cp ./flags/* /usr/share/ipfetch/
-chmod -R 755 /usr/share/ipfetch
+mkdir -p ~/.local/share/ipfetch
+cp ./flags/* ~/.local/share/ipfetch/
+chmod -R 755 ~/.local/share/ipfetch
 
-cp ./ipfetch /usr/bin/
-chmod 755 /usr/bin/ipfetch
+cp ./ipfetch ~/.local/bin/
+chmod 755 ~/.local/bin/ipfetch
 
-echo "ipfetch has been sucesfully installed."
+echo "ipfetch has been succesfully installed."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -6,6 +6,6 @@ fi
 
 rm ~/.local/share/ipfetch/*
 rmdir ~/.local/share/ipfetch
-rm /usr/bin/ipfetch
+rm ~/.local/bin/ipfetch
 
 ipfetch || echo "ipfetch has been successfully uninstalled."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -8,4 +8,4 @@ rm ~/.local/share/ipfetch/*
 rmdir ~/.local/share/ipfetch
 rm /usr/bin/ipfetch
 
-ipfetch || echo "ipfetch has been sucesfully uninstalled."
+ipfetch || echo "ipfetch has been successfully uninstalled."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -4,8 +4,8 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
-rm /usr/share/ipfetch/*
-rmdir /usr/share/ipfetch
+rm ~/.local/share/ipfetch/*
+rmdir ~/.local/share/ipfetch
 rm /usr/bin/ipfetch
 
 ipfetch || echo "ipfetch has been sucesfully uninstalled."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
-if [[ $EUID -ne 0 ]]; then
-   echo "Uninstall script must be run as root" 
-   exit 1
-fi
 
 rm ~/.local/share/ipfetch/*
 rmdir ~/.local/share/ipfetch


### PR DESCRIPTION
# Changes:
- /usr/share/ipfetch -> ~/.local/share/ipfetch
- /usr/bin/ipfetch -> ~/.local/bin/ipfetch
- Minor typo fixes

I initially forked this repo to create a NixOS-specific way to install ipfetch (as per my fork name), but I believe that this could be of use for everyone.

# Benefits:
- Allows successful install on immutable systems
- Removes the need to elevate permissions during install ( ~/.local is user-modifiable)